### PR TITLE
Drop support for Node < 4 and update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 
 node_js:
-  - "0.10"
+  - "4"
+  - "6"
+  - "8"
 
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   "dependencies": {
     "commander": "^2.8.1",
     "debug": "^3.1.0",
-    "file-exists": "~1.0.0",
-    "find": "0.2.6",
-    "requirejs": "~2.2.0",
-    "requirejs-config-file": "~2.0.0"
+    "file-exists": "^2.0.0",
+    "find": "^0.2.8",
+    "requirejs": "^2.3.5",
+    "requirejs-config-file": "^3.0.0"
   },
   "devDependencies": {
     "babel": "~5.8.38",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "babel": "~5.8.38",
     "jscs": "~2.11.0",
     "jscs-preset-mrjoelkemp": "~1.0.0",
-    "mocha": "~2.4.5",
-    "rewire": "~2.3.4",
-    "sinon": "~1.15.4"
+    "mocha": "^4.1.0",
+    "rewire": "^3.0.2",
+    "sinon": "^4.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/mrjoelkemp/node-module-lookup-amd/issues"
   },
   "homepage": "https://github.com/mrjoelkemp/node-module-lookup-amd",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "dependencies": {
     "commander": "^2.8.1",
     "debug": "^3.1.0",


### PR DESCRIPTION
Note that there's already file-exists 5.0 but anything newer than 2.0 only supports Node.js 6 and newer.