### PR TITLE
fix: pass file path when calling requirejs.toUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ module.exports = function(options) {
 
   depPath = stripLoader(depPath);
 
-  var normalizedModuleId = requirejs.toUrl(depPath);
+  var normalizedModuleId = requirejs.toUrl(depPath + '.js');
 
   var resolved = path.join(resolutionDirectory, normalizedModuleId);
 


### PR DESCRIPTION
Since `requirejs.toUrl` accepts a file path instead of module name, this line will cause `../../foo` parsed as `./.../foo`. In this case, `./foo` is recognized (incorrectly) as an extension name.

See `.toUrl` implementation: https://github.com/requirejs/r.js/blob/master/require.js#L1478

This will solve this issue: https://github.com/pahen/madge/issues/132