### PR TITLE
test case: multiple `..` breaks lookup

### DIFF
--- a/test/example/js/subdir/subsubdir/a.js
+++ b/test/example/js/subdir/subsubdir/a.js
@@ -1,0 +1,1 @@
+define(['../../b', '../c'], function(b) {});

--- a/test/test.js
+++ b/test/test.js
@@ -101,6 +101,20 @@ describe('lookup', function() {
     }), path.join(directory, 'vendor/jquery.js'));
   });
 
+  it.only('resolves from subdir', function() {
+    assert.equal(lookup({
+      partial: '../c',
+      filename: `${directory}/subdir/subsubdir/a.js`,
+    }), path.join(directory, 'subdir/c.js'));
+  });
+
+  it.only('resolves from sub subdir', function() {
+    assert.equal(lookup({
+      partial: '../../b',
+      filename: `${directory}/subdir/subsubdir/a.js`,
+    }), path.join(directory, 'b.js'));
+  });
+
   it('resolves style imports', function() {
     assert.equal(lookup({
       config,


### PR DESCRIPTION
This pr contains test cases showing that lookup doesn't work with paths like `../../foo`.