### PR TITLE
Pin requirejs-config-file to maintain compatability with Node.js 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "file-exists": "^2.0.0",
     "find": "^0.2.8",
     "requirejs": "^2.3.5",
-    "requirejs-config-file": "^3.0.0"
+    "requirejs-config-file": "3.0.0"
   },
   "devDependencies": {
     "babel": "~5.8.38",


### PR DESCRIPTION
SemVer is hard.

`requirejs-config-file` 3.1 removed support for Node.js 4. This PR pins `requirejs-config-file` to version 3.0.0 to keep supporting Node.js 4. I suggest to release this as a patch release ASAP.

I'll follow-up with a PR for a new major version that drops Node.js 4 for this package.