### PR TITLE
Drop support for Node.js 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
-  - "4"
   - "6"
   - "8"
+  - "10"
 
 notifications:
   email: false

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,9 +2,9 @@
 
 'use strict';
 
-var lookup = require('../');
+const lookup = require('../');
 
-var program = require('commander');
+const program = require('commander');
 
 program
   .version(require('../package.json').version)
@@ -14,9 +14,9 @@ program
   .option('-d, --directory <path>', 'directory containing all files')
   .parse(process.argv);
 
-var config = program.config;
-var filename = program.filename;
-var partial = program.args[0];
+const config = program.config;
+const filename = program.filename;
+const partial = program.args[0];
 
 console.log(lookup({
   config: config,

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var ConfigFile = require('requirejs-config-file').ConfigFile;
-var fs = require('fs');
-var path = require('path');
-var debug = require('debug')('lookup');
-var find = require('find');
-var fileExists = require('file-exists');
-var requirejs = require('requirejs');
+const ConfigFile = require('requirejs-config-file').ConfigFile;
+const fs = require('fs');
+const path = require('path');
+const debug = require('debug')('lookup');
+const find = require('find');
+const fileExists = require('file-exists');
+const requirejs = require('requirejs');
 
 /**
  * Determines the real path of a potentially aliased dependency path
@@ -22,10 +22,10 @@ var requirejs = require('requirejs');
  * @return {String}
  */
 module.exports = function(options) {
-  var configPath = options.configPath;
-  var config = options.config || {};
-  var depPath = options.partial;
-  var filename = options.filename;
+  let configPath = options.configPath;
+  let config = options.config || {};
+  let depPath = options.partial;
+  let filename = options.filename;
 
   debug('config: ', config);
   debug('partial: ', depPath);
@@ -48,7 +48,7 @@ module.exports = function(options) {
     debug('set baseUrl to ' + config.baseUrl);
   }
 
-  var resolutionDirectory;
+  let resolutionDirectory;
 
   if (configPath) {
     resolutionDirectory = configPath;
@@ -73,7 +73,7 @@ module.exports = function(options) {
 
   depPath = stripLoader(depPath);
 
-  var normalizedModuleId = requirejs.toUrl(depPath);
+  let normalizedModuleId = requirejs.toUrl(depPath);
   debug('requirejs normalized module id: ' + normalizedModuleId);
 
   if (normalizedModuleId.indexOf('...') != -1) {
@@ -82,7 +82,7 @@ module.exports = function(options) {
     debug('expanded module id: ' + normalizedModuleId);
   }
 
-  var resolved = path.join(resolutionDirectory, normalizedModuleId);
+  const resolved = path.join(resolutionDirectory, normalizedModuleId);
 
   debug('resolved url: ' + resolved);
 
@@ -93,7 +93,7 @@ module.exports = function(options) {
     return resolved;
   }
 
-  var foundFile = findFileLike(normalizedModuleId, resolved) || '';
+  const foundFile = findFileLike(normalizedModuleId, resolved) || '';
 
   if (foundFile) {
     debug('found file like ' + resolved + ': ' + foundFile);
@@ -105,15 +105,15 @@ module.exports = function(options) {
 };
 
 function findFileLike(partial, resolved) {
-  var fileDir = path.dirname(resolved);
+  const fileDir = path.dirname(resolved);
 
-  var pattern = escapeRegExp(resolved + '.');
+  const pattern = escapeRegExp(resolved + '.');
 
   debug('looking for file like ' + pattern);
   debug('within ' + fileDir);
 
   try {
-    var results = find.fileSync(new RegExp(pattern), fileDir);
+    const results = find.fileSync(new RegExp(pattern), fileDir);
 
     debug('found the following matches: ', results.join('\n'));
 
@@ -128,7 +128,7 @@ function findFileLike(partial, resolved) {
 }
 
 function stripLoader(partial) {
-  var exclamationLocation = partial.indexOf('!');
+  const exclamationLocation = partial.indexOf('!');
 
   if (exclamationLocation !== -1) {
     debug('stripping off the plugin loader from ' + partial);

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = function(options) {
 
   // No need to search for a file that already has an extension
   // Need to guard against jquery.min being treated as a real file
-  if (path.extname(resolved) && fileExists(resolved)) {
+  if (path.extname(resolved) && fileExists.sync(resolved)) {
     debug(resolved + ' already has an extension and is a real file');
     return resolved;
   }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ConfigFile = require('requirejs-config-file').ConfigFile;
+const {ConfigFile} = require('requirejs-config-file');
 const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('lookup');

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var ConfigFile = require('requirejs-config-file').ConfigFile;
 var fs = require('fs');
 var path = require('path');

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = function(options) {
   let normalizedModuleId = requirejs.toUrl(depPath);
   debug('requirejs normalized module id: ' + normalizedModuleId);
 
-  if (normalizedModuleId.indexOf('...') != -1) {
+  if (normalizedModuleId.includes('...')) {
     debug('detected a nested subdirectory resolution that needs to be expanded');
     normalizedModuleId = normalizedModuleId.replace('.../', '../../');
     debug('expanded module id: ' + normalizedModuleId);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "file-exists": "^2.0.0",
     "find": "^0.2.8",
     "requirejs": "^2.3.5",
-    "requirejs-config-file": "3.0.0"
+    "requirejs-config-file": "^3.1.1"
   },
   "devDependencies": {
     "babel": "~5.8.38",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "commander": "^2.8.1",
-    "debug": "^3.1.0",
+    "debug": "^4.1.0",
     "file-exists": "^2.0.0",
     "find": "^0.2.8",
     "requirejs": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/mrjoelkemp/node-module-lookup-amd",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "dependencies": {
     "commander": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "jscs": "~2.11.0",
     "jscs-preset-mrjoelkemp": "~1.0.0",
-    "mocha": "^4.1.0",
+    "mocha": "^5.2.0",
     "rewire": "^3.0.2",
     "sinon": "^4.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jscs": "~2.11.0",
     "jscs-preset-mrjoelkemp": "~1.0.0",
     "mocha": "^5.2.0",
-    "rewire": "^3.0.2",
+    "rewire": "^4.0.1",
     "sinon": "^7.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "jscs-preset-mrjoelkemp": "~1.0.0",
     "mocha": "^5.2.0",
     "rewire": "^3.0.2",
-    "sinon": "^4.1.3"
+    "sinon": "^7.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "commander": "^2.8.1",
     "debug": "^4.1.0",
-    "file-exists": "^2.0.0",
+    "file-exists": "^5.0.1",
     "find": "^0.2.8",
     "requirejs": "^2.3.5",
     "requirejs-config-file": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Resolve aliased dependency paths using a RequireJS config",
   "main": "index.js",
   "scripts": {
-    "test": "jscs index.js test bin && ./node_modules/.bin/mocha --compilers js:babel/register test/test.js"
+    "test": "jscs index.js test bin && mocha test/test.js"
   },
   "bin": {
     "lookup-amd": "bin/cli.js"
@@ -37,7 +37,6 @@
     "requirejs-config-file": "^3.1.1"
   },
   "devDependencies": {
-    "babel": "~5.8.38",
     "jscs": "~2.11.0",
     "jscs-preset-mrjoelkemp": "~1.0.0",
     "mocha": "^4.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const path = require('path');
-const ConfigFile = require('requirejs-config-file').ConfigFile;
+const {ConfigFile} = require('requirejs-config-file');
 const rewire = require('rewire');
 const sinon = require('sinon');
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var assert = require('assert');
-var path = require('path');
-var ConfigFile = require('requirejs-config-file').ConfigFile;
-var rewire = require('rewire');
-var sinon = require('sinon');
+const assert = require('assert');
+const path = require('path');
+const ConfigFile = require('requirejs-config-file').ConfigFile;
+const rewire = require('rewire');
+const sinon = require('sinon');
 
-var lookup = rewire('../');
+const lookup = rewire('../');
 
-var directory;
-var filename;
-var config;
+let directory;
+let filename;
+let config;
 
 describe('lookup', function() {
   beforeEach(function() {
@@ -36,7 +36,7 @@ describe('lookup', function() {
   });
 
   it('returns the looked up path given a loaded requirejs config object', function() {
-    var configObject = new ConfigFile(config).read();
+    const configObject = new ConfigFile(config).read();
     assert.equal(lookup({
       config: configObject,
       configPath: config,
@@ -135,7 +135,7 @@ describe('lookup', function() {
   });
 
   it('does not throw if the baseUrl is missing', function() {
-    var configObject = new ConfigFile(config).read();
+    const configObject = new ConfigFile(config).read();
     delete configObject.baseUrl;
 
     assert.doesNotThrow(function() {
@@ -149,7 +149,7 @@ describe('lookup', function() {
   });
 
   it('does not throw if config.map is missing', function() {
-    var configObject = new ConfigFile(config).read();
+    const configObject = new ConfigFile(config).read();
     delete configObject.map;
 
     assert.doesNotThrow(function() {
@@ -163,7 +163,7 @@ describe('lookup', function() {
   });
 
   it('does not throw if config.paths is missing', function() {
-    var configObject = new ConfigFile(config).read();
+    const configObject = new ConfigFile(config).read();
     delete configObject.paths;
 
     assert.doesNotThrow(function() {
@@ -189,7 +189,7 @@ describe('lookup', function() {
   describe('when no baseUrl is in the config', function() {
     describe('and a configPath is supplied', function() {
       it('defaults the directory containing the config file', function() {
-        var configObject = new ConfigFile(config).read();
+        const configObject = new ConfigFile(config).read();
         delete configObject.baseUrl;
 
         assert.equal(lookup({
@@ -203,7 +203,7 @@ describe('lookup', function() {
 
     describe('and the configPath was not supplied', function() {
       it('defaults to the directory containing the given file', function() {
-        var configObject = new ConfigFile(config).read();
+        const configObject = new ConfigFile(config).read();
         delete configObject.baseUrl;
 
         assert.equal(lookup({

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var assert = require('assert');
 var path = require('path');
 var ConfigFile = require('requirejs-config-file').ConfigFile;


### PR DESCRIPTION
As promised in #22, this PR drops support for Node.js 4. I used some of the new JS features and updated all dependencies that were blocked by supporting Node.js 4.

Lastly, I removed the dev dependency on babel. The code works in Node.js 6 as-is so it's no longer needed.