### PR TITLE
Update dependencies to support alternative fs and fix tests in windows.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('lookup');
 const find = require('find');
-const fileExists = require('file-exists');
+const fileExists = require('file-exists-dazinatorfork');
 const requirejs = require('requirejs');
 
 /**
@@ -91,7 +91,6 @@ module.exports = function(options) {
   // No need to search for a file that already has an extension
   // Need to guard against jquery.min being treated as a real file
 
-  // TODO: The below options will be ignored until file-exists dependency updated to version with merged PR.
   if (path.extname(resolved) && fileExists.sync(resolved, {fileSystem: fileSystem})) {
     debug(resolved + ' already has an extension and is a real file');
     return resolved;

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = function(options) {
     return resolved;
   }
 
-  const foundFile = findFileLike(normalizedModuleId, resolved) || '';
+    const foundFile = findFileLike(fileSystem, normalizedModuleId, resolved) || '';
 
   if (foundFile) {
     debug('found file like ' + resolved + ': ' + foundFile);
@@ -108,7 +108,7 @@ module.exports = function(options) {
   return foundFile;
 };
 
-function findFileLike(partial, resolved) {
+function findFileLike(fileSystem, partial, resolved) {
   const fileDir = path.dirname(resolved);
 
   const pattern = escapeRegExp(resolved + '.');
@@ -116,8 +116,10 @@ function findFileLike(partial, resolved) {
   debug('looking for file like ' + pattern);
   debug('within ' + fileDir);
 
-  try {
-    const results = find.fileSync(new RegExp(pattern), fileDir);
+    try {
+              
+    const results = find.use({ fs: fileSystem })
+                        .fileSync(new RegExp(pattern), fileDir); 
 
     debug('found the following matches: ', results.join('\n'));
 

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = function(options) {
     return resolved;
   }
 
-    const foundFile = findFileLike(fileSystem, normalizedModuleId, resolved) || '';
+  const foundFile = findFileLike(fileSystem, normalizedModuleId, resolved) || '';
 
   if (foundFile) {
     debug('found file like ' + resolved + ': ' + foundFile);
@@ -116,11 +116,9 @@ function findFileLike(fileSystem, partial, resolved) {
   debug('looking for file like ' + pattern);
   debug('within ' + fileDir);
 
-    try {
-              
-    const results = find.use({ fs: fileSystem })
-                        .fileSync(new RegExp(pattern), fileDir); 
-
+  try {
+    const results = find.use({fs: fileSystem})
+                        .fileSync(new RegExp(pattern), fileDir);
     debug('found the following matches: ', results.join('\n'));
 
     // Not great if there are multiple matches, but the pattern should be

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "commander": "^2.8.1",
     "debug": "^4.1.0",
     "file-exists": "^5.0.1",
-    "find": "^0.2.8",
+    "find": "^0.3.0",
     "requirejs": "^2.3.5",
     "requirejs-config-file": "^3.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "commander": "^2.8.1",
     "debug": "^4.1.0",
-    "file-exists": "^5.0.1",
+    "file-exists-dazinatorfork": "^1.0.2",
     "find": "^0.3.0",
     "requirejs": "^2.3.5",
     "requirejs-config-file": "^3.1.1"

--- a/test/test.js
+++ b/test/test.js
@@ -14,9 +14,9 @@ let config;
 
 describe('lookup', function() {
   beforeEach(function() {
-    directory = __dirname + '/example/js';
-    filename = directory + '/a.js';
-    config = __dirname + '/example/config.json';
+    directory = path.normalize(__dirname + '/example/js');
+    filename = path.normalize(directory + '/a.js');
+    config = path.normalize(__dirname + '/example/config.json');
   });
 
   it('returns the real path of an aliased module given a path to a requirejs config file', function() {


### PR DESCRIPTION
- [x] update `file-exists` dependency, to accept fileSystem option (original author of file-exists dependency was unresponsive, so this PR switches to my fork of that (MIT licence in play) with the necessary minor tweak necessary.
- [x] update `find` dependency, to accept fileSystem option.
- [x] Fix the tests on windows by using path.normalize()

