### PR TITLE
Require Node.js 10 + simplify dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 
 node_js:
   - "10"
-  - "12.15"
+  - "12"
+  - "14"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 
 node_js:
-  - "6"
-  - "8"
   - "10"
+  - "12.15"
 
 notifications:
   email: false

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('lookup');
 const find = require('find');
-const fileExists = require('file-exists-dazinatorfork');
 const requirejs = require('requirejs');
 
 /**
@@ -91,7 +90,7 @@ module.exports = function(options) {
   // No need to search for a file that already has an extension
   // Need to guard against jquery.min being treated as a real file
 
-  if (path.extname(resolved) && fileExists.sync(resolved, {fileSystem: fileSystem})) {
+  if (path.extname(resolved) && fileExists(resolved, fileSystem)) {
     debug(resolved + ' already has an extension and is a real file');
     return resolved;
   }
@@ -127,6 +126,21 @@ function findFileLike(fileSystem, partial, resolved) {
   } catch (e) {
     debug('error when looking for a match: ' + e.message);
     return '';
+  }
+}
+
+function fileExists(filepath = '', fileSystem = fs) {
+  try {
+    return fileSystem.statSync(filepath).isFile();
+  }
+  catch (e) {
+    // Check exception. If ENOENT - no such file or directory ok, file doesn't exist.
+    // Otherwise something else went wrong, we don't have rights to access the file, ...
+    if (e.code != 'ENOENT') {
+      throw e;
+    }
+
+    return false;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "commander": "^2.8.1",
     "debug": "^4.1.0",
-    "file-exists-dazinatorfork": "^1.0.2",
     "find": "^0.3.0",
     "requirejs": "^2.3.5",
     "requirejs-config-file": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "file-exists-dazinatorfork": "^1.0.2",
     "find": "^0.3.0",
     "requirejs": "^2.3.5",
-    "requirejs-config-file": "^3.1.1"
+    "requirejs-config-file": "^4.0.0"
   },
   "devDependencies": {
     "jscs": "^3.0.7",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "jscs": "^3.0.7",
     "jscs-preset-mrjoelkemp": "^2.0.0",
     "mocha": "^8.2.1",
-    "rewire": "^5.0.0",
     "sinon": "^9.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/mrjoelkemp/node-module-lookup-amd",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.13.0"
   },
   "dependencies": {
     "commander": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "requirejs-config-file": "^3.1.1"
   },
   "devDependencies": {
-    "jscs": "~2.11.0",
-    "jscs-preset-mrjoelkemp": "~1.0.0",
-    "mocha": "^5.2.0",
-    "rewire": "^4.0.1",
-    "sinon": "^7.2.0"
+    "jscs": "^3.0.7",
+    "jscs-preset-mrjoelkemp": "^2.0.0",
+    "mocha": "^8.2.1",
+    "rewire": "^5.0.0",
+    "sinon": "^9.2.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -3,10 +3,9 @@
 const assert = require('assert');
 const path = require('path');
 const {ConfigFile} = require('requirejs-config-file');
-const rewire = require('rewire');
 const sinon = require('sinon');
 
-const lookup = rewire('../');
+const lookup = require('../');
 
 let directory;
 let filename;


### PR DESCRIPTION
This PR remove 4 dependencies from `module-lookup-amd`. 3 by upgrading `require-js-config-file` and another by pulling in a much simpler version of `fileExists` into the module.

The minimum Node version is set to 10.13 as that is the version of the first Node 10 LTS. `require-js-config-file` requires this version as it uses a feature introduced in 10.12.