### PR TITLE
fix: Security vulnerability - Bump requirejs to version 2.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "commander": "^12.0.0",
         "glob": "^7.2.3",
-        "requirejs": "^2.3.6",
+        "requirejs": "^2.3.7",
         "requirejs-config-file": "^4.0.0"
       },
       "bin": {
@@ -5381,9 +5381,9 @@
       }
     },
     "node_modules/requirejs": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
-      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.7.tgz",
+      "integrity": "sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw==",
       "bin": {
         "r_js": "bin/r.js",
         "r.js": "bin/r.js"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "commander": "^12.0.0",
     "glob": "^7.2.3",
-    "requirejs": "^2.3.6",
+    "requirejs": "^2.3.7",
     "requirejs-config-file": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue described here:

https://github.com/dependents/node-module-lookup-amd/issues/40
